### PR TITLE
fix hung on CloseEventHandle

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -1,12 +1,15 @@
+//go:build windows
 // +build windows
 
 package main
 
 import (
 	"fmt"
-	"time"
-
 	winlog "github.com/ofcoursedude/gowinlog"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
 )
 
 func main() {
@@ -19,6 +22,10 @@ func main() {
 	if err != nil {
 		fmt.Printf("Couldn't subscribe to Application: %v", err)
 	}
+
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
+
 	for {
 		select {
 		case evt := <-watcher.Event():
@@ -27,6 +34,14 @@ func main() {
 			fmt.Printf("Bookmark: %v\n", bookmark)
 		case err := <-watcher.Error():
 			fmt.Printf("Error: %v\n\n", err)
+		default:
+		}
+
+		select {
+		case <-c:
+			fmt.Println("Shutting down")
+			watcher.Shutdown()
+			return
 		default:
 			// If no event is waiting, need to wait or do something else, otherwise
 			// the the app fails on deadlock.

--- a/structs.go
+++ b/structs.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package winlog
@@ -64,7 +65,7 @@ type WinLogWatcher struct {
 
 	renderContext SysRenderContext
 	watches       map[string]*channelWatcher
-	watchMutex    sync.Mutex
+	watchMutex    sync.RWMutex
 	shutdown      chan interface{}
 
 	// Optionally render localized fields. EvtFormatMessage() is slow, so


### PR DESCRIPTION
* PublishEvent is called from the thread which is different from thread which calls Shutdown. So if event comes after RemoveSubscription acquire watchMutex.Lock() PublishEvent will be locked on the attempt to acquire the same lock and CloseEventHandle will hang forever. The solution is to use RWMutex and RLock instead of Lock
* Extend example with SIGINT & SIGTERM handler