### PR TITLE
923 support  omuzychuk fix access to invalid memory in evt format message

### DIFF
--- a/event.go
+++ b/event.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package winlog
@@ -71,6 +72,11 @@ func FormatMessage(eventPublisherHandle PublisherHandle, eventHandle EventHandle
 			return "", err
 		}
 	}
+
+	if size == 0 {
+		return "empty event message", nil
+	}
+
 	buf := make([]uint16, size)
 	err = EvtFormatMessage(syscall.Handle(eventPublisherHandle), syscall.Handle(eventHandle), 0, 0, nil, uint32(format), uint32(len(buf)), &buf[0], &size)
 	if err != nil {
@@ -171,10 +177,10 @@ func getTestEventHandle() (EventHandle, error) {
 	var recordsReturned uint32
 	err = EvtNext(handle, 1, &record, 500, 0, &recordsReturned)
 	if err != nil {
-		EvtClose(handle)
+		_ = EvtClose(handle)
 		return 0, nil
 	}
-	EvtClose(handle)
+	_ = EvtClose(handle)
 	return EventHandle(record), nil
 }
 

--- a/example/main.go
+++ b/example/main.go
@@ -1,12 +1,15 @@
+//go:build windows
 // +build windows
 
 package main
 
 import (
 	"fmt"
-	"time"
-
 	winlog "github.com/ofcoursedude/gowinlog"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
 )
 
 func main() {
@@ -19,6 +22,10 @@ func main() {
 	if err != nil {
 		fmt.Printf("Couldn't subscribe to Application: %v", err)
 	}
+
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
+
 	for {
 		select {
 		case evt := <-watcher.Event():
@@ -27,6 +34,14 @@ func main() {
 			fmt.Printf("Bookmark: %v\n", bookmark)
 		case err := <-watcher.Error():
 			fmt.Printf("Error: %v\n\n", err)
+		default:
+		}
+
+		select {
+		case <-c:
+			fmt.Println("Shutting down")
+			watcher.Shutdown()
+			return
 		default:
 			// If no event is waiting, need to wait or do something else, otherwise
 			// the the app fails on deadlock.

--- a/structs.go
+++ b/structs.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package winlog
@@ -64,7 +65,7 @@ type WinLogWatcher struct {
 
 	renderContext SysRenderContext
 	watches       map[string]*channelWatcher
-	watchMutex    sync.Mutex
+	watchMutex    sync.RWMutex
 	shutdown      chan interface{}
 
 	// Optionally render localized fields. EvtFormatMessage() is slow, so


### PR DESCRIPTION
* If the message is empty we try to allocate buffer with zero
   size for it and then pass a pointer to 0 element of the buffer
   to EvtFormatMessage - it is illegal in Go
